### PR TITLE
Whitespace only changes to remove JS Standard warnings

### DIFF
--- a/lib/acl-control.js
+++ b/lib/acl-control.js
@@ -52,14 +52,14 @@ UI.aclControl.preventBrowserDropEvents = function (document) {
   document.addEventListener('dragover', preventDrag, false)
 }
 
-UI.aclControl.shortNameForFolder = function(x) {
+UI.aclControl.shortNameForFolder = function (x) {
   var str = x.uri
   if (str.slice(-1) === '/') {
-    str = str.slice(0,-1)
+    str = str.slice(0, -1)
   }
   var slash = str.lastIndexOf('/')
-  if (slash >= 0){
-    str = str.slice(slash+1)
+  if (slash >= 0) {
+    str = str.slice(slash + 1)
   }
   return str || '/'
 }
@@ -328,7 +328,7 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
           console.log('Dropped URI list (2): ' + uris)
           if (uris) {
             uris.map(function (u) {
-              var saveAndRestoreUI = function(){
+              var saveAndRestoreUI = function () {
                 if (!(combo in byCombo)) {
                   byCombo[combo] = []
                 }
@@ -346,9 +346,9 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
               var res = agentTriage(u) // eg 'agent', 'origin', agentClass'
               if (!res) {
                 console.log('   looking up dropped thing ' + u)
-                kb.fetcher.nowOrWhenFetched(u, function(ok, mess){
+                kb.fetcher.nowOrWhenFetched(u, function (ok, mess) {
                   if (!ok) {
-                    console.log('Error looking up dropped thing '+u + ': ' + mess)
+                    console.log('Error looking up dropped thing ' + u + ': ' + mess)
                   } else {
                     var res = agentTriage(u)
                     if (!res) {


### PR DESCRIPTION
Fixes all JS Standard warnings for file :

    lib/acl-control.js

Confirmed as whitespace only:

    git diff -w
     
